### PR TITLE
Issue #3: prometheus-demo.yaml uses obsolete apiVersion

### DIFF
--- a/kubernetes/prometheus-deployment.yaml
+++ b/kubernetes/prometheus-deployment.yaml
@@ -1,10 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-deployment
   namespace: prometheus
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-server
   template:
     metadata:
       labels:


### PR DESCRIPTION
Upped apiVersion to apps/v1 and added spec.selector section. File now loads and works on Kubernetes 1.17.